### PR TITLE
Chore/remove username from model

### DIFF
--- a/src/openapi.yml
+++ b/src/openapi.yml
@@ -116,11 +116,7 @@ components:
         password:
           type: string
           title: Password
-        username:
-          type: string
-          title: Username
       required:
-        - username
         - email
         - password
         - first_name

--- a/src/scripts/generate_jwt_token.py
+++ b/src/scripts/generate_jwt_token.py
@@ -13,7 +13,6 @@ def generate_jwt_token():
         payload={
             "token_id": str(uuid.uuid4()),
             "user_id": "user123",
-            "username": "John Doe",
             "email": "john.doe@example.com",
             "created_at": DATETIME_NOW_TIMESTAMP,
             "expires_at": int((DATETIME_NOW + datetime.timedelta(days=1)).timestamp()),

--- a/src/smart_cart/models/token.py
+++ b/src/smart_cart/models/token.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 class TokenPayload(BaseModel):
     token_id: str = str(uuid.uuid4())
     user_id: str
-    username: str
     email: str
     created_at: int
     expires_at: int

--- a/src/smart_cart/models/user.py
+++ b/src/smart_cart/models/user.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, EmailStr
 
 class User(BaseModel):
     user_id: str
-    username: str
     email: EmailStr
     hashed_password: str
     first_name: str
@@ -21,7 +20,6 @@ class User(BaseModel):
     def from_dynamoItem(cls, item: dict) -> "User":
         return cls(
             user_id=item["user_id"],
-            username=item["username"],
             email=item["email"],
             hashed_password=item["hashed_password"],
             first_name=item["first_name"],
@@ -36,7 +34,6 @@ class User(BaseModel):
 
 
 class UserSignUp(BaseModel):
-    username: str
     email: EmailStr
     password: str
     first_name: str

--- a/src/smart_cart/repositories/users.py
+++ b/src/smart_cart/repositories/users.py
@@ -28,7 +28,6 @@ class User(Model):
         host = settings.host
 
     user_id = UnicodeAttribute(hash_key=True)
-    username = UnicodeAttribute()
     email = UnicodeAttribute()
     email_index = EmailIndex()
     hashed_password = UnicodeAttribute()
@@ -45,7 +44,6 @@ class User(Model):
     def from_entity(cls, model: UserModel):
         return cls(
             user_id=model.user_id,
-            username=model.username,
             email=model.email,
             hashed_password=model.hashed_password,
             first_name=model.first_name,

--- a/src/smart_cart/routers/login.py
+++ b/src/smart_cart/routers/login.py
@@ -29,7 +29,6 @@ def login(user_login: UserLogin, status_code=status.HTTP_200_OK):
         "token_type": "bearer",
         "user": {
             "user_id": user.user_id,
-            "username": user.username,
             "email": user.email,
             "first_name": user.first_name,
             "last_name": user.last_name,

--- a/src/smart_cart/routers/signup.py
+++ b/src/smart_cart/routers/signup.py
@@ -23,7 +23,6 @@ def signup(user_signup: UserSignUp):
 
     user = User(
         user_id=str(uuid.uuid4()),
-        username=user_signup.username,
         email=user_signup.email,
         hashed_password=hashed_password,
         first_name=user_signup.first_name,
@@ -43,7 +42,6 @@ def signup(user_signup: UserSignUp):
         "token_type": "bearer",
         "user": {
             "user_id": user.user_id,
-            "username": user.username,
             "email": user.email,
             "first_name": user.first_name,
             "last_name": user.last_name,

--- a/src/smart_cart/utils/auth.py
+++ b/src/smart_cart/utils/auth.py
@@ -22,7 +22,6 @@ def create_access_token(user: User) -> str:
     token_payload = TokenPayload(
         token_id=str(uuid.uuid4()),
         user_id=user.user_id,
-        username=user.username,
         email=user.email,
         created_at=DATETIME_NOW_TIMESTAMP,
         expires_at=int((DATETIME_NOW + datetime.timedelta(days=1)).timestamp()),

--- a/src/smart_cart/utils/factories.py
+++ b/src/smart_cart/utils/factories.py
@@ -11,7 +11,6 @@ from smart_cart.utils.constants import DATETIME_NOW, DATETIME_NOW_TIMESTAMP
 def token_payload_factory(
     token_id: Optional[str] = None,
     user_id: str = "user123",
-    username: str = "John Doe",
     email: str = "john.doe@example.com",
     created_at: Optional[int] = None,
     expires_at: Optional[int] = None,
@@ -23,7 +22,6 @@ def token_payload_factory(
     return TokenPayload(
         token_id=token_id,
         user_id=user_id,
-        username=username,
         email=email,
         created_at=created_at,
         expires_at=expires_at,
@@ -31,7 +29,6 @@ def token_payload_factory(
 
 
 def user_signup_factory(
-    username: str = "john_doe",
     email: Optional[str] = None,
     password: str = "password",
     first_name: str = "John",
@@ -39,7 +36,6 @@ def user_signup_factory(
 ):
     email = email or f"user_{uuid.uuid4()}@example.com"
     return UserSignUp(
-        username=username,
         email=email,
         password=password,
         first_name=first_name,
@@ -49,7 +45,6 @@ def user_signup_factory(
 
 def user_factory(
     user_id: Optional[str] = None,
-    username: str = "john_doe",
     email: Optional[str] = None,
     hashed_password: Optional[str] = None,
     first_name: str = "John",
@@ -68,7 +63,6 @@ def user_factory(
 
     return User(
         user_id=user_id,
-        username=username,
         email=email,
         hashed_password=hashed_password,
         first_name=first_name,

--- a/src/tests/models/token_test.py
+++ b/src/tests/models/token_test.py
@@ -11,7 +11,6 @@ def test_token_payload():
 
     assert token_payload.token_id == token["token_id"]
     assert token_payload.user_id == token["user_id"]
-    assert token_payload.username == token["username"]
     assert token_payload.email == token["email"]
     assert token_payload.created_at == token["created_at"]
     assert token_payload.expires_at == token["expires_at"]

--- a/src/tests/models/user_test.py
+++ b/src/tests/models/user_test.py
@@ -17,7 +17,6 @@ def test_user():
     user_schema = User(**user)
 
     assert user_schema.user_id == user["user_id"]
-    assert user_schema.username == user["username"]
     assert user_schema.email == user["email"]
     assert user_schema.hashed_password == user["hashed_password"]
     assert user_schema.first_name == user["first_name"]
@@ -40,7 +39,6 @@ def test_user():
     "field, invalid_value",
     [
         ("user_id", 123),
-        ("username", ""),
         ("email", "invalid_email"),
         ("hashed_password", ""),
         ("first_name", ""),
@@ -78,7 +76,6 @@ def test_user_sign_up():
 
     user_sign_up_schema = UserSignUp(**user_sign_up)
 
-    assert user_sign_up_schema.username == user_sign_up["username"]
     assert user_sign_up_schema.email == user_sign_up["email"]
     assert user_sign_up_schema.password == user_sign_up["password"]
     assert user_sign_up_schema.first_name == user_sign_up["first_name"]
@@ -88,7 +85,6 @@ def test_user_sign_up():
 @pytest.mark.parametrize(
     "field, invalid_value",
     [
-        ("username", ""),
         ("email", "invalid_email"),
         ("password", ""),
         ("first_name", ""),

--- a/src/tests/repositories/users_test.py
+++ b/src/tests/repositories/users_test.py
@@ -38,13 +38,13 @@ def test_update_user(user_repository):
     user = user_factory()
     user_repository.create_user(user)
 
-    user.username = "new_username"
+    user.email = "new.email@example.com"
 
     user_repository.update_user(user)
 
     updated_user = user_repository.get_user(user.user_id)
 
-    assert updated_user.username == "new_username"
+    assert updated_user.email == "new.email@example.com"
 
 
 def test_login_user(user_repository):

--- a/src/tests/routers/login_test.py
+++ b/src/tests/routers/login_test.py
@@ -41,7 +41,6 @@ def test_user_login_should_return_access_token(client, user_repository):
         "token_type": "bearer",
         "user": {
             "user_id": user.user_id,
-            "username": user.username,
             "email": user.email,
             "first_name": user.first_name,
             "last_name": user.last_name,
@@ -52,7 +51,6 @@ def test_user_login_should_return_access_token(client, user_repository):
     token_payload = jwt.decode(response.json()["access_token"], settings.token_payload_secret_key, algorithms=["HS256"])
 
     assert token_payload["user_id"] == user.user_id
-    assert token_payload["username"] == user.username
     assert token_payload["email"] == user.email
     assert token_payload["expires_at"]
     assert token_payload["created_at"]

--- a/src/tests/routers/signup_test.py
+++ b/src/tests/routers/signup_test.py
@@ -30,7 +30,6 @@ def test_signup_should_return_201(client):
         **jwt.decode(response.json()["access_token"], settings.token_payload_secret_key, algorithms=["HS256"])
     )
 
-    assert token_payload.username == user_sign_up.username
     assert token_payload.email == user_sign_up.email
     assert token_payload.user_id
     assert token_payload.created_at
@@ -38,7 +37,6 @@ def test_signup_should_return_201(client):
     assert token_payload.expires_at > token_payload.created_at
 
     assert response.json()["user"]["user_id"]
-    assert response.json()["user"]["username"] == user_sign_up.username
     assert response.json()["user"]["email"] == user_sign_up.email
     assert response.json()["user"]["first_name"] == user_sign_up.first_name
     assert response.json()["user"]["last_name"] == user_sign_up.last_name

--- a/src/tests/utils/auth_test.py
+++ b/src/tests/utils/auth_test.py
@@ -32,7 +32,6 @@ def test_create_access_token():
 
     assert isinstance(UUID(decoded_token["token_id"]), UUID)
     assert decoded_token["user_id"] == user.user_id
-    assert decoded_token["username"] == user.username
     assert decoded_token["email"] == user.email
     assert decoded_token["created_at"] is not None
     assert decoded_token["expires_at"] is not None


### PR DESCRIPTION
We already have one unique value per user (email); the need for a unique username adds unnecessary complexity to the app, which I do not intend to maintain. Email is generally a better way to differentiate between users, so we remove the username attribute.